### PR TITLE
Otherloader Tutorial Block Support + Other Fixes

### DIFF
--- a/Assets/MeatKit/Tools/Editor/IconCameraEditor.cs
+++ b/Assets/MeatKit/Tools/Editor/IconCameraEditor.cs
@@ -64,7 +64,7 @@ public class IconCameraEditor : Editor {
 
         if (GUILayout.Button("Take Picture"))
         {
-            Selection.activeGameObject.GetComponent<IconCamera>().Capture();
+            iconCamera.Capture();
         }
     }
 }


### PR DESCRIPTION
## What's new in this pull request:

- Added tutorial block support to `OtherloaderBuildItem`
- Added support for custom list of BepInEx dependancies to the `OtherLoaderBuildRoot`
- Added optional fields to `ItemSpawnerEntry` allowing for referencing FVRObjects instead of by string IDs
- Small improvements to `ItemSpawnerEntry` editor
- Fixed IconCamera not being able to take pictures when not selected

***Note: many of these changes are hidden inside the Unity Package***

***Another Note: I have tested these changes on my end using a fresh install of meatkit off this fork***