### PR TITLE
Create gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Assets/Alloy/**   linguist-vendored


### PR DESCRIPTION
This prevents GitHub from overwhelmingly representing the repository as GLSL/HLSL shaders, that being from the `Alloy` directory.