### PR TITLE
Change to LZ4 compression for better on demand loading and some QoL additions to the Enum related fuctions

### DIFF
--- a/Assets/MeatKit/Editor/AssemblyModifiers/EnumModifierEditor.cs
+++ b/Assets/MeatKit/Editor/AssemblyModifiers/EnumModifierEditor.cs
@@ -12,8 +12,10 @@ namespace MeatKit
             "FistVR.FireArmRoundType",
             "FistVR.FireArmRoundClass",
             "FistVR.FireArmMagazineType",
-            "FistVR.ItemSpawnerObjectDefinition.ItemSpawnerCategory",
-            "FistVR.SosigEnemyID"
+            "FistVR.ItemSpawnerObjectDefinition+ItemSpawnerCategory",
+            "FistVR.SosigEnemyID",
+            "FistVR.FVRFireArmAttachementMountType",
+            "FistVR.FireArmClipType"
         };
 
         private SerializedProperty _addedValues;

--- a/Assets/MeatKit/Editor/Build.cs
+++ b/Assets/MeatKit/Editor/Build.cs
@@ -92,7 +92,7 @@ namespace MeatKit
             BuildLog.WriteLine("Collecting bundles from build items");
             var bundles = profile.BuildItems.SelectMany(x => x.ConfigureBuild()).ToArray();
             BuildLog.WriteLine(bundles.Length + " bundles to build. Building bundles.");
-            BuildPipeline.BuildAssetBundles(bundleOutputPath, bundles, BuildAssetBundleOptions.None,
+            BuildPipeline.BuildAssetBundles(bundleOutputPath, bundles, BuildAssetBundleOptions.ChunkBasedCompression,
                 BuildTarget.StandaloneWindows64);
             
             // Disable bundle processing now that we're done with it.

--- a/Assets/MeatKit/Editor/BuildPipeline/BuildProfile.cs
+++ b/Assets/MeatKit/Editor/BuildPipeline/BuildProfile.cs
@@ -218,7 +218,7 @@ namespace MeatKit
             // ReSharper disable once CoVariantArrayConversion
             obj["dependencies"] = new JArray(GetRequiredDependencies().Concat(AdditionalDependencies).ToArray());
 
-            File.WriteAllText(location, JsonConvert.SerializeObject(obj));
+            File.WriteAllText(location, JsonConvert.SerializeObject(obj,Formatting.Indented));
 #endif
         }
     }

--- a/Assets/MeatKit/Editor/Tools/EnumPicker.cs
+++ b/Assets/MeatKit/Editor/Tools/EnumPicker.cs
@@ -185,6 +185,7 @@ public class EnumPicker : PropertyDrawer
 [CustomPropertyDrawer(typeof(ItemSpawnerID.ESubCategory))]
 [CustomPropertyDrawer(typeof(FireArmRoundType))]
 [CustomPropertyDrawer(typeof(SosigEnemyID))]
+[CustomPropertyDrawer(typeof(FVRFireArmAttachementMountType))]
 public class EnumDrawers : EnumPicker
 {
 }

--- a/Assets/MeatKit/Editor/Utils/AssemblyStripper.cs
+++ b/Assets/MeatKit/Editor/Utils/AssemblyStripper.cs
@@ -83,7 +83,7 @@ namespace NStrip
 						var nonSerializedAttributeRef = assembly.MainModule.ImportReference(nonSerializedAttributeCtor);
 						attributes.Add(new CustomAttribute(nonSerializedAttributeRef));
 						
-						var hideInInspectorCtor = typeof(HideInInspector).GetConstructor(Type.EmptyTypes);
+						var hideInInspectorCtor = typeof(MeatKit.HideInNormalInspectorAttribute).GetConstructor(Type.EmptyTypes);
 						var hideInInspectorRef = assembly.MainModule.ImportReference(hideInInspectorCtor);
 						attributes.Add(new CustomAttribute(hideInInspectorRef));
 						

--- a/Assets/MeatKit/Editor/Utils/HideInNormalInspectorDrawer.cs
+++ b/Assets/MeatKit/Editor/Utils/HideInNormalInspectorDrawer.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+using UnityEditor;
+
+namespace MeatKit
+{
+    [CustomPropertyDrawer(typeof(HideInNormalInspectorAttribute))]
+    class HideInNormalInspectorDrawer : PropertyDrawer
+    {
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return 0f;
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) { }
+    }
+}

--- a/Assets/MeatKit/Editor/Utils/HideInNormalInspectorDrawer.cs.meta
+++ b/Assets/MeatKit/Editor/Utils/HideInNormalInspectorDrawer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0c4b5d56cc4522845a6ca6bb3d6d76f0
+timeCreated: 1667603705
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MeatKit/HideInNormalInspectorAttribute.cs
+++ b/Assets/MeatKit/HideInNormalInspectorAttribute.cs
@@ -1,0 +1,5 @@
+using UnityEngine;
+namespace MeatKit
+{
+    public class HideInNormalInspectorAttribute : PropertyAttribute { }
+}

--- a/Assets/MeatKit/HideInNormalInspectorAttribute.cs.meta
+++ b/Assets/MeatKit/HideInNormalInspectorAttribute.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3f2d0027e67ba7c45bebe5483a614d44
+timeCreated: 1667603705
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Includes a custom `HideInInspector `attribute (`HideInNormalInspector`) that makes it so that private fields are hidden unless in Debug mode.
- Also added some more Enum types to the Enum picker and EnumModifier classes to choose from.