### PR TITLE
Inspector and PlayHelper fixes

### DIFF
--- a/Assets/MeatKit/Editor/PlayHelper.cs
+++ b/Assets/MeatKit/Editor/PlayHelper.cs
@@ -275,6 +275,27 @@ public static class PlayHelper
             Log("Disabled existing camera: " + existing[i].gameObject.name);
         }
 
+        // Scene cameras can carry their own AudioListener; only [EditorVRCamera] should have one.
+        // FindObjectsOfTypeAll (not FindObjectsOfType) -- a leftover [EditorVRCamera] from an
+        // earlier session is HideFlags.DontSave, which FindObjectsOfType silently can't see,
+        // letting its enabled listener go undetected and accumulate session after session.
+        AudioListener[] existingListeners = Resources.FindObjectsOfTypeAll<AudioListener>();
+        for (int i = 0; i < existingListeners.Length; i++)
+        {
+            // FindObjectsOfTypeAll can also return a component sitting on a loaded prefab
+            // asset (e.g. a weapon scope prefab with its own AudioListener) rather than a
+            // scene instance; IsPersistent tells them apart. Never touch a project asset.
+            if (UnityEditor.EditorUtility.IsPersistent(existingListeners[i].gameObject)) continue;
+
+            existingListeners[i].enabled = false;
+            Log("Disabled existing AudioListener: " + existingListeners[i].gameObject.name);
+        }
+
+        // FVRSceneSettings' real Start() (vault scenario load, etc.) can spawn more objects
+        // with their own AudioListener after this one-time pass already ran; keep enforcing
+        // exactly one for the rest of the session, see EnforceSingleAudioListener.
+        UnityEditor.EditorApplication.update += EnforceSingleAudioListener;
+
         // Capture scene-view position, then detach the scene-view camera from VR tracking.
         Vector3 spawnPos;
         Quaternion spawnRot;
@@ -301,14 +322,42 @@ public static class PlayHelper
         vrCam.farClipPlane    = 1000f;
         vrCam.clearFlags      = CameraClearFlags.Skybox;
         vrCam.depth           = 10;
-        vrCam.stereoTargetEye = StereoTargetEyeMask.Both;  // explicit: this camera renders to the HMD
+        vrCam.stereoTargetEye = StereoTargetEyeMask.None;  // enabled after a warm-up delay, see EnableVrStereoWhenReady
+        _vrCamListener = camGO.AddComponent<AudioListener>();
         camGO.transform.position = spawnPos;
         camGO.transform.rotation = spawnRot;
+
+        // Enabling stereo immediately can race Unity's own native OpenVR handshake and crash
+        // inside vrclient_x64.dll on a NULL this-pointer; wait a moment before enabling it.
+        _pendingVrCam = vrCam;
+        _vrCamStereoEnableAt = UnityEditor.EditorApplication.timeSinceStartup + VrStereoWarmupDelaySeconds;
+        UnityEditor.EditorApplication.update += EnableVrStereoWhenReady;
 
         // Unity's VR system can re-enable stereo on the scene-view camera each frame.
         // Register an editor-update callback to keep it detached for the entire play session.
         UnityEditor.EditorApplication.update += KeepSceneViewDetachedFromVR;
         UnityEditor.EditorApplication.playmodeStateChanged += OnPlaymodeChanged;
+    }
+
+    private static Camera _pendingVrCam;
+    private static double _vrCamStereoEnableAt;
+    private const double VrStereoWarmupDelaySeconds = 1.0;
+
+    // Delays the [EditorVRCamera]'s stereo output by VrStereoWarmupDelaySeconds so Unity's
+    // native OpenVR init has time to finish before the first stereo render is attempted.
+    private static void EnableVrStereoWhenReady()
+    {
+        if (_pendingVrCam == null)
+        {
+            UnityEditor.EditorApplication.update -= EnableVrStereoWhenReady;
+            return;
+        }
+        if (UnityEditor.EditorApplication.timeSinceStartup < _vrCamStereoEnableAt) return;
+
+        _pendingVrCam.stereoTargetEye = StereoTargetEyeMask.Both;
+        Log("[EditorVRCamera] stereo enabled after warm-up delay.");
+        _pendingVrCam = null;
+        UnityEditor.EditorApplication.update -= EnableVrStereoWhenReady;
     }
 
     // Unsubscribes the per-frame scene-view guard when play mode ends.
@@ -318,7 +367,37 @@ public static class PlayHelper
             !UnityEditor.EditorApplication.isPlayingOrWillChangePlaymode)
         {
             UnityEditor.EditorApplication.update -= KeepSceneViewDetachedFromVR;
+            UnityEditor.EditorApplication.update -= EnableVrStereoWhenReady;
+            UnityEditor.EditorApplication.update -= EnforceSingleAudioListener;
             UnityEditor.EditorApplication.playmodeStateChanged -= OnPlaymodeChanged;
+
+            // [EditorVRCamera] uses HideFlags.DontSave, so it survives Stop instead of being
+            // cleaned up -- disable its listener here or it's left enabled indefinitely (and
+            // the next Play session's [EditorVRCamera] would just add another one on top).
+            if (_vrCamListener != null) _vrCamListener.enabled = false;
+
+            _pendingVrCam = null;
+            _vrCamListener = null;
+        }
+    }
+
+    private static AudioListener _vrCamListener;
+
+    // Disables every AudioListener except [EditorVRCamera]'s own. Checked every frame rather
+    // than throttled -- a scenario/vault load can spawn a burst of new listeners at once, and
+    // a throttled check left a window where Unity would log its warning before the next pass.
+    // Uses FindObjectsOfTypeAll -- see the matching note in OnAfterSceneLoad.
+    private static void EnforceSingleAudioListener()
+    {
+        AudioListener[] listeners = Resources.FindObjectsOfTypeAll<AudioListener>();
+        for (int i = 0; i < listeners.Length; i++)
+        {
+            if (listeners[i] != _vrCamListener && listeners[i].enabled &&
+                !UnityEditor.EditorUtility.IsPersistent(listeners[i].gameObject))
+            {
+                listeners[i].enabled = false;
+                Log("Disabled newly-spawned AudioListener: " + listeners[i].gameObject.name);
+            }
         }
     }
 
@@ -394,28 +473,24 @@ public static class PlayHelper
             if (fxmType != null)
                 PatchAwakeWithSwallow(fxmType);
 
+            // SetReverbEnvironment needs a real AudioMixer this bootstrap doesn't provide.
+            // SM.Update no longer needs a skip patch -- confirmed against the full log file
+            // (not just a tail window, which is too small to catch a fast-repeating exception)
+            // that the current game version's own null-guards let it run for real, with zero
+            // exceptions.
             if (smType != null)
-            {
                 PatchSafely(AccessTools.Method(smType, "SetReverbEnvironment"), skip);
-                // SM.Update NPEs on null TinnitusSound; no-op it.
-                PatchSafely(AccessTools.Method(smType, "Update"), skip);
-            }
 
+            // AchCheck() reads GM.CurrentMovementManager.transform with no null-guard; this
+            // bootstrap has no real MovementManager, so it NREs every single Update() tick
+            // (10,100 times in one 60s session) unless skip-patched.
             if (ssType != null)
-            {
-                PatchSafely(AccessTools.Method(ssType, "Start"), skip);
                 PatchSafely(AccessTools.Method(ssType, "Update"), skip);
-            }
 
             // CurrentPlayerBody is null in editor.
             Type aicType = ResolveFromH3VR("FistVR.AudioImpactController");
             if (aicType != null)
                 PatchSafely(AccessTools.Method(aicType, "OnCollisionEnter"), skip);
-
-            // Reads GM.CurrentMovementManager which is null in editor.
-            Type w1873Type = ResolveFromH3VR("FistVR.Winchester1873LoadingGate");
-            if (w1873Type != null)
-                PatchSafely(AccessTools.Method(w1873Type, "Update"), skip);
 
             // DllNotFoundException from haptic feedback DLL; no-op if not installed.
             Type forceTubeType = ResolveFromH3VR("ForceTubeVRInterface");

--- a/Assets/MeatKit/Editor/Utils/EditorVersion.cs
+++ b/Assets/MeatKit/Editor/Utils/EditorVersion.cs
@@ -21,6 +21,7 @@ namespace MeatKit
         public long RenewMonoScriptsFromAssemblies { get; set; }
         public long ReleaseMonoScriptCaches { get; set; }
         public long IsCompatibleWithEditorCPUAndOS { get; set; }
+        public long GetMonoManagerPtr { get; set; }
     }
 
     public class EditorVersion
@@ -89,7 +90,8 @@ namespace MeatKit
                         TransferScriptingObjectGTT = 0xE4CA80,
                         RenewMonoScriptsFromAssemblies = 0x14C6910,
                         ReleaseMonoScriptCaches = 0x14C66F0,
-                        IsCompatibleWithEditorCPUAndOS = 0x1601D10
+                        IsCompatibleWithEditorCPUAndOS = 0x1601D10,
+                        GetMonoManagerPtr = 0x14C2510
                     }
                 }
             },

--- a/Assets/MeatKit/Editor/Utils/ManagedPluginDomainFix.cs
+++ b/Assets/MeatKit/Editor/Utils/ManagedPluginDomainFix.cs
@@ -65,6 +65,15 @@ namespace MeatKit
             AppDomain.CurrentDomain.AssemblyResolve += ResolveUnityExtensionAssembly;
             CopyH3VRCodeDlls(true);
             NativeHookManager.BeforeShutdownCallbacks.Add(delegate { CopyH3VRCodeDlls(false); });
+            // Fixes edited scripts never reflecting changes without a full Editor restart.
+            if (EditorVersion.Current.FunctionOffsets.GetMonoManagerPtr != 0)
+            {
+                NativeHookManager.BeforeShutdownCallbacks.Add(delegate
+                {
+                    try { CaptureAndEvictStaleScriptAssemblyImages(); }
+                    catch (Exception ex) { Debug.LogWarning("[ManagedPluginDomainFix] CaptureAndEvictStaleScriptAssemblyImages failed: " + ex.Message); }
+                });
+            }
 
             // Note: PIOLA and RUA hooks cannot be installed safely from an [InitializeOnLoad]
             // static ctor. ShutdownManaged + BeforeEATI callbacks cover all required work.
@@ -1059,6 +1068,187 @@ namespace MeatKit
             {
                 BuildLog.WriteLine("ReprimeSingleNativeScript: " + ex.Message);
             }
+        }
+
+        // GetMonoManagerPtr() -- trivial no-arg accessor, called directly (never detoured).
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate IntPtr d_GetMonoManagerPtr();
+
+        private static d_GetMonoManagerPtr _getMonoManagerPtr;
+        private static bool _getMonoManagerPtrResolveFailed;
+
+        private static IntPtr ResolveMonoManagerPtr()
+        {
+            if (_getMonoManagerPtr == null)
+            {
+                if (_getMonoManagerPtrResolveFailed) return IntPtr.Zero;
+                long rva = EditorVersion.Current.FunctionOffsets.GetMonoManagerPtr;
+                if (rva == 0) { _getMonoManagerPtrResolveFailed = true; return IntPtr.Zero; }
+                IntPtr unityBase = GetUnityModule();
+                if (unityBase == IntPtr.Zero) return IntPtr.Zero;
+                IntPtr fnPtr = (IntPtr)(unityBase.ToInt64() + rva);
+                _getMonoManagerPtr = (d_GetMonoManagerPtr)Marshal.GetDelegateForFunctionPointer(fnPtr, typeof(d_GetMonoManagerPtr));
+            }
+            return _getMonoManagerPtr();
+        }
+
+        // MonoImage* vector on MonoManager: begin ptr at +520, end ptr at +528, 8 bytes/element.
+        // Indices 0-2 are core assemblies; ordinary script assemblies start at index 3.
+        private const int MonoImagesVectorBeginOffset = 520;
+        private const int MonoImagesVectorEndOffset = 528;
+        private const int FirstOrdinaryScriptAssemblyIndex = 3;
+
+        // mono.dll's internal (non-exported) name-cache hash table lookup/remove, resolved by RVA.
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate IntPtr d_g_hash_table_lookup(IntPtr hashTable, IntPtr key);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int d_g_hash_table_remove(IntPtr hashTable, IntPtr key);
+
+        private static d_g_hash_table_lookup _monoImagesHashLookup;
+        private static d_g_hash_table_remove _monoImagesHashRemove;
+
+        // MonoImage struct field offsets used as register_image's cache keys, plus the two
+        // name-cache hash tables and the mutex mono.dll itself locks around them.
+        private const int MonoImageFlagsOffset = 28;
+        private const int MonoImageNameOffset = 32;
+        private const int MonoImageAssemblyNameOffset = 40;
+        private const long LoadedImagesHashGlobalRva = 0x265750;
+        private const long LoadedImagesRefonlyHashGlobalRva = 0x265780;
+        private const long HashLookupFunctionRva = 0x2278;
+        private const long HashRemoveFunctionRva = 0x24DC;
+        private const long ImagesLockInitedFlagRva = 0x265788;
+        private const long ImagesMutexRva = 0x265758;
+
+        [DllImport("kernel32.dll")]
+        private static extern void EnterCriticalSection(IntPtr lpCriticalSection);
+
+        [DllImport("kernel32.dll")]
+        private static extern void LeaveCriticalSection(IntPtr lpCriticalSection);
+
+        // Used to confirm a native pointer is actually mapped before dereferencing it.
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MEMORY_BASIC_INFORMATION
+        {
+            public IntPtr BaseAddress;
+            public IntPtr AllocationBase;
+            public uint AllocationProtect;
+            public IntPtr RegionSize;
+            public uint State;
+            public uint Protect;
+            public uint Type;
+        }
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr VirtualQuery(IntPtr lpAddress, out MEMORY_BASIC_INFORMATION lpBuffer, UIntPtr dwLength);
+
+        private const uint MEM_COMMIT = 0x1000;
+        private const uint PAGE_NOACCESS = 0x01;
+        private const uint PAGE_GUARD = 0x100;
+
+        private static bool IsReadablePointer(IntPtr addr)
+        {
+            if (addr == IntPtr.Zero) return false;
+            MEMORY_BASIC_INFORMATION mbi;
+            IntPtr queryResult = VirtualQuery(addr, out mbi, (UIntPtr)Marshal.SizeOf(typeof(MEMORY_BASIC_INFORMATION)));
+            if (queryResult == IntPtr.Zero) return false;
+            if (mbi.State != MEM_COMMIT) return false;
+            if ((mbi.Protect & PAGE_NOACCESS) != 0) return false;
+            if ((mbi.Protect & PAGE_GUARD) != 0) return false;
+            return true;
+        }
+
+        private static bool EnsureMonoInternalHashDelegatesLoaded(out IntPtr monoModule)
+        {
+            monoModule = GetMonoModule();
+            if (monoModule == IntPtr.Zero) return false;
+            if (_monoImagesHashLookup != null && _monoImagesHashRemove != null) return true;
+
+            IntPtr lookupPtr = (IntPtr)(monoModule.ToInt64() + HashLookupFunctionRva);
+            IntPtr removePtr = (IntPtr)(monoModule.ToInt64() + HashRemoveFunctionRva);
+            _monoImagesHashLookup = (d_g_hash_table_lookup)Marshal.GetDelegateForFunctionPointer(lookupPtr, typeof(d_g_hash_table_lookup));
+            _monoImagesHashRemove = (d_g_hash_table_remove)Marshal.GetDelegateForFunctionPointer(removePtr, typeof(d_g_hash_table_remove));
+            return true;
+        }
+
+        // Removes a stale MonoImage's entries from register_image's name-cache so the next load
+        // creates a fresh image instead of reusing this one. Never closes/frees the image itself --
+        // just unlinks the cache entry, which is enough to fix the staleness and avoids the crashes
+        // that came from actually closing a still-referenced image.
+        private static void EvictStaleImageFromNameCache(IntPtr staleImage)
+        {
+            IntPtr monoModule;
+            if (!EnsureMonoInternalHashDelegatesLoaded(out monoModule)) return;
+
+            if (!IsReadablePointer(staleImage))
+            {
+                Debug.LogWarning("[ManagedPluginDomainFix] EvictStaleImageFromNameCache: rejected unreadable staleImage=0x" + staleImage.ToInt64().ToString("X"));
+                return;
+            }
+
+            byte flags = Marshal.ReadByte(staleImage, MonoImageFlagsOffset);
+            IntPtr nameKey = Marshal.ReadIntPtr(staleImage, MonoImageNameOffset);
+            IntPtr assemblyNameKey = Marshal.ReadIntPtr(staleImage, MonoImageAssemblyNameOffset);
+
+            if (!IsReadablePointer(nameKey)) nameKey = IntPtr.Zero;
+            if (!IsReadablePointer(assemblyNameKey)) assemblyNameKey = IntPtr.Zero;
+
+            long hashGlobalRva = (flags & 0x8) != 0 ? LoadedImagesRefonlyHashGlobalRva : LoadedImagesHashGlobalRva;
+            IntPtr hashTable = Marshal.ReadIntPtr((IntPtr)(monoModule.ToInt64() + hashGlobalRva));
+            if (hashTable == IntPtr.Zero) return;
+
+            IntPtr mutexAddr = (IntPtr)(monoModule.ToInt64() + ImagesMutexRva);
+            bool lockInited = Marshal.ReadInt32((IntPtr)(monoModule.ToInt64() + ImagesLockInitedFlagRva)) != 0;
+            if (lockInited) EnterCriticalSection(mutexAddr);
+            try
+            {
+                if (nameKey != IntPtr.Zero && _monoImagesHashLookup(hashTable, nameKey) == staleImage)
+                    _monoImagesHashRemove(hashTable, nameKey);
+                if (assemblyNameKey != IntPtr.Zero && _monoImagesHashLookup(hashTable, assemblyNameKey) == staleImage)
+                    _monoImagesHashRemove(hashTable, assemblyNameKey);
+            }
+            finally
+            {
+                if (lockInited) LeaveCriticalSection(mutexAddr);
+            }
+        }
+
+        // Called each reload via BeforeShutdownCallbacks, before this reload's own LoadAssemblies
+        // runs. Reads every ordinary script-assembly slot off MonoManager and evicts it from the
+        // name-cache immediately, so edited scripts actually get reloaded instead of Mono silently
+        // reusing the previous compile forever (the root cause of scripts never reflecting changes
+        // without a full Editor restart).
+        private static void CaptureAndEvictStaleScriptAssemblyImages()
+        {
+            IntPtr pMonoManager = ResolveMonoManagerPtr();
+            if (pMonoManager == IntPtr.Zero) return;
+
+            IntPtr begin = Marshal.ReadIntPtr(pMonoManager, MonoImagesVectorBeginOffset);
+            IntPtr end = Marshal.ReadIntPtr(pMonoManager, MonoImagesVectorEndOffset);
+            if (begin == IntPtr.Zero || end == IntPtr.Zero || end.ToInt64() <= begin.ToInt64()) return;
+
+            long elementCount = (end.ToInt64() - begin.ToInt64()) / 8;
+            int evicted = 0;
+            for (long i = FirstOrdinaryScriptAssemblyIndex; i < elementCount; i++)
+            {
+                IntPtr slotAddr = new IntPtr(begin.ToInt64() + i * 8);
+                IntPtr image = Marshal.ReadIntPtr(slotAddr);
+                if (image == IntPtr.Zero) continue;
+                // The last one or two entries are sometimes an unmapped pointer at this exact
+                // moment -- skip rather than risk dereferencing it.
+                if (!IsReadablePointer(image)) continue;
+                try
+                {
+                    EvictStaleImageFromNameCache(image);
+                    evicted++;
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogWarning("[ManagedPluginDomainFix] EvictStaleImageFromNameCache failed for 0x" + image.ToInt64().ToString("X") + ": " + ex.Message);
+                }
+            }
+            if (evicted > 0)
+                Log("CaptureAndEvictStaleScriptAssemblyImages: evicted " + evicted + " image(s) from the name-cache");
         }
 
         private static void Log(string msg)

--- a/Assets/MeatKit/Editor/Utils/NativeHookManager.cs
+++ b/Assets/MeatKit/Editor/Utils/NativeHookManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -581,9 +581,9 @@ namespace MeatKit
 
         private static void OnShutdownManaged()
         {
-            // Fire pre-shutdown callbacks, then dispose detours BEFORE native teardown
-            // so CRT atexit handlers (which fire during exit()) don't deadlock on the
-            // still-active NativeDetour callbacks.
+            // Unity is about to shutdown the mono runtime! Quickly dispose of our detours!
+            // Fire any registered pre-shutdown callbacks before tearing down the domain.
+            // try/finally guarantees OrigShutdownManaged() is called even if a callback throws.
             try
             {
                 foreach (var cb in BeforeShutdownCallbacks)
@@ -594,13 +594,18 @@ namespace MeatKit
             }
             finally
             {
-                // Dispose detours first — metadata writes can now complete.
-                foreach (var detour in Detours) detour.Dispose();
-                Detours.Clear();
-
+                // Kill Mono IO-worker threads before teardown - they block in uninterruptible I/O
+                // waits, causing STOA to deadlock during domain unload.
                 TerminateMonoIOWorkers();
 
-                OrigShutdownManaged();
+                try
+                {
+                    OrigShutdownManaged();
+                }
+                finally
+                {
+                    foreach (var detour in Detours) detour.Dispose();
+                }
             }
         }
 


### PR DESCRIPTION
Inspector will now update fields and headers for all scripts after decompilation. There was a path that was not being refreshed despite the fact that the underlying code was updated, the inspector fields wouldn't reflect any changes. This doesn't matter for H3VR code, but does matter for custom authored .cs scripts. Now the fields will reflect normally after each recompile within the editor allowing code changes for fields without a Unity Editor restart.

PlayHelper was hardened to have better null reference exception handling, catches for a SteamVR dll crash, and AudioListener checks on activation.